### PR TITLE
Add string-based log level support to KafkaSingleton

### DIFF
--- a/lib/kafka/kafkaSingleton.js
+++ b/lib/kafka/kafkaSingleton.js
@@ -1,4 +1,4 @@
-const {Kafka} = require('kafkajs');
+const {Kafka, logLevel} = require('kafkajs');
 
 /**
  * Singleton class for Kafka client.
@@ -13,23 +13,40 @@ class KafkaSingleton {
   }
 
   /**
+   * Maps string log levels to Kafka log level constants.
+   * @param {string} level - The string log level.
+   * @return {number} Corresponding Kafka log level.
+   */
+  static mapLogLevel(level) {
+    const levels = {
+      'error': logLevel.ERROR,
+      'warn': logLevel.WARN,
+      'info': logLevel.INFO,
+      'debug': logLevel.DEBUG,
+      'nothing': logLevel.NOTHING,
+    };
+    return levels[level] || logLevel.INFO; // Default to INFO if not matched
+  }
+
+  /**
    * Initializes the Kafka instance if it's not already created.
    * @param {string} clientId - The client ID for the Kafka client.
    * @param {string[]} brokers - The list of broker addresses.
    * @param {function} logCreator - Function to create the logger (optional).
-   * @param {string} logLevel - Logging level (optional).
+   * @param {string} loggingLevel - Logging level (optional).
    */
-  static initialize(clientId, brokers, logCreator, logLevel) {
+  static initialize(clientId, brokers, logCreator, loggingLevel) {
     if (!this.instance) {
       const kafkaConfig = {clientId, brokers};
 
-      // Add logCreator and logLevel if they are defined
+      // Add logCreator if they are defined
       if (logCreator !== undefined) {
         kafkaConfig.logCreator = logCreator;
       }
 
-      if (logLevel !== undefined) {
-        kafkaConfig.logLevel = logLevel;
+      // Add logLevel if defined, mapping from string to Kafka log level
+      if (loggingLevel !== undefined) {
+        kafkaConfig.logLevel = this.mapLogLevel(loggingLevel);
       }
 
       try {


### PR DESCRIPTION
Enhanced the KafkaSingleton class to allow specifying log levels as strings ('error', 'warn', 'info', 'debug', 'nothing') instead of using Kafka's log level constants. Implemented a mapping function, mapLogLevel, to convert these strings to the corresponding Kafka log level constants. Updated the initialize method to utilize this new functionality, providing a more user-friendly approach to setting log levels.